### PR TITLE
Use faster Chromium build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Create a batch script inside `automate`, name `build.bat`. If the name change do
 
 ```
 set CEF_USE_GN=1
-set GN_DEFINES=is_official_build=true proprietary_codecs=true ffmpeg_branding=Chrome
+set GN_DEFINES=is_official_build=true proprietary_codecs=true ffmpeg_branding=Chrome enable_nacl=false blink_symbol_level=0 symbol_level=0
 set GYP_MSVS_VERSION=2019
 set CEF_ARCHIVE_FORMAT=tar.bz2
 python automate-git.py --download-dir=c:\code\chromium_git --depot-tools-dir=c:\code\depot_tools --branch=4240 --minimal-distrib --client-distrib --force-clean --no-debug-build


### PR DESCRIPTION
I came across these flags while researching ways to build chromium more quickly. They are applicable here because we don't need to debug the chromium build itself. I don't have a build time comparison, but I can confirm that my copy of Spotify continued to work when using chromium built with these flags.

I did not try changing the `target_cpu` flag because it seemed somewhat likely to cause breakage and I didn't really want to have to do another build.
I did not try a component build because it has an application startup cost, and I like spotify to start quickly.

These may be interesting targets for future build time improvements.

Reference:
https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#faster-builds