### PR TITLE
Canvas Added to Now Playing View

### DIFF
--- a/Extensions/getCanvas.js
+++ b/Extensions/getCanvas.js
@@ -136,15 +136,19 @@
     };
 
     class CanvasHandler {
+      static canvasWrapperSelector = {
+        fs: "#main > div > div:nth-child(5)", // Full screen
+        npv: "#VideoPlayerNpv_ReactPortal" // Now Playing View
+      }
       static canvasExists = false;
       static canvasURL = "";
 
       static inFullscreen() {
-        let fsDiv = document.querySelectorAll("#main > div > div:nth-child(5)");
+        let fsDiv = document.querySelector(this.canvasWrapperSelector.fs);
         return (
           document.documentElement.classList.contains("fullscreen") &&
-          fsDiv.length > 0 &&
-          fsDiv[0].hasChildNodes()
+          fsDiv &&
+          fsDiv.hasChildNodes()
         );
       }
 
@@ -166,6 +170,7 @@
 
       static createWrapper() {
         log("[Canvas/CanvasHandler] Canvas video element appended to DOM.");
+        let canvasWrapperElem = null;
         let canvasWrapper = document.createElement("div");
         canvasWrapper.id = "CanvasWrapper";
         let video = document.createElement("video");
@@ -178,27 +183,49 @@
         video.setAttribute("preload", "none");
         video.setAttribute("type", "video/mp4");
         canvasWrapper.appendChild(video);
-
+        
         // add wrapper to DOM
-        let fullscreenElem = document.querySelectorAll(
-          "#main > div > div:nth-child(5) > div" // selects the fullscreen div
-        );
-        if (fullscreenElem.length > 0) {
-          fullscreenElem[0].appendChild(canvasWrapper);
+        if (this.inFullscreen()){
+          canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.fs);
+        } else {
+          canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.npv);
         }
+
+        if (canvasWrapperElem) {
+          canvasWrapperElem.appendChild(canvasWrapper);
+        }
+        
         return canvasWrapper;
       }
 
       static getWrapper() {
-        let wrapper = document.getElementById("CanvasWrapper");
+        let wrapper = null;
+        if(this.inFullscreen()){
+          wrapper = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper");
+        } else {
+          wrapper = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper");
+        }
         if (!wrapper) {
+          this.clearWrapper();
           wrapper = this.createWrapper();
         }
         return wrapper;
       }
 
+      static clearWrapper() {
+        let wrapper = document.getElementById("CanvasWrapper");
+        if (wrapper) {
+          wrapper.remove();
+        }
+      }
+
       static getVideo() {
-        let video = document.getElementById("CanvasDisplay");
+        let video = null;
+        if(this.inFullscreen()){
+          video = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper > #CanvasDisplay");
+        } else {
+          video = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper > #CanvasDisplay");
+        }
         if (!video) {
           video = this.getWrapper().children.namedItem("CanvasDisplay");
         }
@@ -206,15 +233,13 @@
       }
 
       static updateVideo() {
-        if (this.inFullscreen()) {
-          let video = this.getVideo();
-          if (this.canvasExists) {
-            if (video.src !== this.canvasURL) {
-              this.setVideo(this.canvasURL);
-            }
-            if (video.paused) {
-              video.play();
-            }
+        let video = this.getVideo();
+        if (this.canvasExists) {
+          if (video.src !== this.canvasURL) {
+            this.setVideo(this.canvasURL);
+          }
+          if (video.paused) {
+            video.play();
           }
         }
       }
@@ -231,16 +256,14 @@
       }
 
       static setVideo(canvas) {
-        if (this.inFullscreen()) {
-          let video = this.getVideo();
-          // set src and update CSS classes to style properly
-          video.src = canvas;
-          this.showCanvas();
+        let video = this.getVideo();
+        // set src and update CSS classes to style properly
+        video.src = canvas;
+        this.showCanvas();
 
-          // Go!
-          video.load();
-          video.play();
-        }
+        // Go!
+        video.load();
+        video.play();
       }
     }
 

--- a/Extensions/getCanvas.js
+++ b/Extensions/getCanvas.js
@@ -1,4 +1,7 @@
 (() => {
+  const config = {
+    enabledViews: ["fs", "npv"] // "fs" Full screen, "npv" Now Playing View
+  };
   const LOGGING = true;
   const importScript = (url) => {
     let script = document.createElement("script");
@@ -186,9 +189,13 @@
         
         // add wrapper to DOM
         if (this.inFullscreen()){
-          canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.fs);
+          if(config.enabledViews.includes("fs")){
+            canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.fs);
+          }
         } else {
-          canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.npv);
+          if(config.enabledViews.includes("npv")){
+            canvasWrapperElem = document.querySelector(this.canvasWrapperSelector.npv);
+          }
         }
 
         if (canvasWrapperElem) {
@@ -201,9 +208,13 @@
       static getWrapper() {
         let wrapper = null;
         if(this.inFullscreen()){
-          wrapper = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper");
+          if(config.enabledViews.includes("fs")){
+            wrapper = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper");
+          }
         } else {
-          wrapper = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper");
+          if(config.enabledViews.includes("npv")){
+            wrapper = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper");
+          }
         }
         if (!wrapper) {
           this.clearWrapper();
@@ -222,9 +233,13 @@
       static getVideo() {
         let video = null;
         if(this.inFullscreen()){
-          video = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper > #CanvasDisplay");
+          if(config.enabledViews.includes("fs")){
+            video = document.querySelector(this.canvasWrapperSelector.fs + " > #CanvasWrapper > #CanvasDisplay");
+          }
         } else {
-          video = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper > #CanvasDisplay");
+          if(config.enabledViews.includes("npv")){
+            video = document.querySelector(this.canvasWrapperSelector.npv + " > #CanvasWrapper > #CanvasDisplay");
+          }
         }
         if (!video) {
           video = this.getWrapper().children.namedItem("CanvasDisplay");

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The extension is designed to show Canvases in the fullscreen view. The following
 ![Canvas w/o mouse overlay](https://i.imgur.com/e5usAdB.png)
 ![Canvas, overlay](https://i.imgur.com/NtJbFgE.png)
 
+## Configuration
+
+The extension has a few configuration options, which can be found in the `getCanvas.js` file under the `config` object. The options are as follows:
+
+- `enabledViews`: An array of views to enable the extension on. Possible values are `"fs"` (Full Screen) and `"npv"` (Now Playing View).
+
 ## How it works
 
 The mobile Spotify client uses a protocol called [Protobuf](https://developers.google.com/protocol-buffers) to communicate with the bridge/cosmos/hermes API and request a canvas link for a given track. However, the Desktop and Web clients do not have protobuf-based implementations and purely send JSON requests.

--- a/Themes/canvas/user.css
+++ b/Themes/canvas/user.css
@@ -2,12 +2,9 @@
 CANVAS!!!
 */
 /* Fill and center canvas, put it between background and title. Hide when not active */
+
 #CanvasWrapper {
   display: none;
-  z-index: 1;
-  position: absolute;
-  top: 0;
-  bottom: 0;
   height: 100%;
   width: 100%;
   align-items: center;
@@ -16,18 +13,29 @@ CANVAS!!!
   background: transparent;
 }
 
+.fullscreen #CanvasWrapper {
+  position: fixed;
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+
 /* Show the canvas! */
 .canvas-show #CanvasWrapper {
   display: flex;
 }
 
-/* Border and shadow the video so it looks nice */
 #CanvasDisplay {
   height: 100%;
-  width: auto;
+  width: 100%;
   background: none;
   margin: 0;
   text-align: center;
+}
+/* Border and shadow the video so it looks nice */
+.fullscreen #CanvasDisplay {
+  width: auto;
   border: 1px solid #00000055;
   border-top-width: 0;
   border-bottom-width: 0;


### PR DESCRIPTION
Canvas is now playable on the new "Now Playing" view. The changes made to the code base are minimal.

The player is cleared and created again when switching between full screen and windowed mode.

Small quality change to the code by replacing `querySelectorAll` with `querySelector`, as only the first element was being used.