### PR TITLE
feat(extensions/getCanvas): feat: use `Spicetify.Player.data.item`

### DIFF
--- a/Extensions/getCanvas.js
+++ b/Extensions/getCanvas.js
@@ -407,7 +407,7 @@
 
       // track change, update canvas
       CanvasHandler.clearCanvas();
-      let res = await client.postCanvasRequest(Spicetify.Player.data.track.uri);
+      let res = await client.postCanvasRequest(Spicetify.Player.data.item.uri);
       if (res.canvases.length > 0) {
         // pick a random canvas if there is multiple
         CanvasHandler.setCanvas(randArray(res.canvases).url);


### PR DESCRIPTION
track property is deprecated since Spicetify v2.23.0 https://github.com/spicetify/spicetify-cli/releases/tag/v2.23.0